### PR TITLE
Add lines number in editor

### DIFF
--- a/editor/buffer.go
+++ b/editor/buffer.go
@@ -129,3 +129,20 @@ func (e *editBuffer) prepend(caret int, s string) {
 	e.gapstart += len(s)
 	e.changed = e.changed || len(s) > 0
 }
+
+func (e *editBuffer) countLinesBeforeOffset(byteOffset int64) int {
+	cnt := 0
+	
+	
+	if byteOffset>= int64(len(e.text)) {
+		byteOffset = int64(len(e.text))
+	}
+
+	for _, c := range e.text[:byteOffset] {
+		if c == '\n' {
+			cnt++
+		}
+	}
+
+	return cnt
+}

--- a/editor/buffer.go
+++ b/editor/buffer.go
@@ -132,9 +132,8 @@ func (e *editBuffer) prepend(caret int, s string) {
 
 func (e *editBuffer) countLinesBeforeOffset(byteOffset int64) int {
 	cnt := 0
-	
-	
-	if byteOffset>= int64(len(e.text)) {
+
+	if byteOffset >= int64(len(e.text)) {
 		byteOffset = int64(len(e.text))
 	}
 

--- a/editor/buffer.go
+++ b/editor/buffer.go
@@ -3,6 +3,7 @@
 package editor
 
 import (
+	"bytes"
 	"io"
 	"unicode/utf8"
 
@@ -11,9 +12,6 @@ import (
 
 // editBuffer implements a gap buffer for text editing.
 type editBuffer struct {
-	// pos is the byte position for Read and ReadRune.
-	pos int
-
 	// The gap start and end in bytes.
 	gapstart, gapend int
 	text             []byte
@@ -137,10 +135,15 @@ func (e *editBuffer) countLinesBeforeOffset(byteOffset int64) int {
 		byteOffset = int64(len(e.text))
 	}
 
-	for _, c := range e.text[:byteOffset] {
-		if c == '\n' {
-			cnt++
+	offset := 0
+	for {
+		index := bytes.IndexByte(e.text[offset:byteOffset], '\n')
+		if index == -1 {
+			break
 		}
+		offset += index
+		cnt++
+		offset++ // Move past the newline
 	}
 
 	return cnt

--- a/editor/editor.go
+++ b/editor/editor.go
@@ -1094,22 +1094,19 @@ func (e *Editor) VisibleLines() ([]*LineInfo, error) {
 	}
 
 	lines := make([]*LineInfo, 0)
-
 	for idx, line := range linePos {
-		//log.Printf("line[%d], y offset: %d, x offset: %d", line.lineCol.line, line.y, line.x.Ceil())
-
 		if idx == 0 {
 			if line.lineCol.line == 0 {
 				lines = append(lines, &LineInfo{
 					LineNum: 1,
-					YOffset: line.y,
-					Start:   0,
+					YOffset: line.y - line.ascent.Ceil(),
+					Start:   line.runes,
 				})
 			} else {
 				startLine := e.buffer.countLinesBeforeOffset(int64(e.text.runeOffset(line.runes)))
 				lines = append(lines, &LineInfo{
-					LineNum: startLine,
-					YOffset: line.y,
+					LineNum: startLine + 1,
+					YOffset: line.y - e.text.ScrollOff().Y - line.ascent.Ceil(),
 					Start:   line.runes,
 				})
 			}
@@ -1122,7 +1119,7 @@ func (e *Editor) VisibleLines() ([]*LineInfo, error) {
 
 		lines = append(lines, &LineInfo{
 			LineNum: lines[idx-1].LineNum + 1,
-			YOffset: line.y,
+			YOffset: line.y - e.text.ScrollOff().Y - line.ascent.Ceil(),
 			Start:   line.runes,
 		})
 

--- a/editor/editor_style.go
+++ b/editor/editor_style.go
@@ -14,8 +14,7 @@ import (
 	"gioui.org/text"
 	"gioui.org/unit"
 	"gioui.org/widget"
-	"gioui.org/widget/material"
-	"github.com/oligo/gioview/theme"
+	"github.com/oligo/gioview/misc"
 )
 
 type EditorStyle struct {
@@ -40,8 +39,15 @@ type EditorStyle struct {
 	shaper *text.Shaper
 }
 
-type LineNumberBar struct {
-	Positions []*LineInfo
+type lineNumberBar struct {
+	shaper          *text.Shaper
+	lineHeight      unit.Sp
+	lineHeightScale float32
+	// Color is the text color.
+	color     color.NRGBA
+	typeFace  font.Typeface
+	textSize  unit.Sp
+	positions []*LineInfo
 }
 
 type EditorConf struct {
@@ -106,22 +112,80 @@ func (e EditorStyle) Layout(gtx layout.Context) layout.Dimensions {
 	}
 	e.Editor.LineHeight = e.LineHeight
 	e.Editor.LineHeightScale = e.LineHeightScale
-	dims = e.Editor.Layout(gtx, e.shaper, e.Font, e.TextSize, textColor, selectionColor)
-	if e.Editor.Len() == 0 {
-		call.Add(gtx.Ops)
-	}
+
+	dims = layout.Flex{
+		Axis: layout.Horizontal,
+	}.Layout(gtx,
+		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			lines, _ := e.Editor.VisibleLines()
+			return lineNumberBar{
+				shaper:          e.shaper,
+				lineHeight:      e.LineHeight,
+				lineHeightScale: e.LineHeightScale,
+				color:           misc.WithAlpha(e.Color, 0xb6),
+				typeFace:        e.Font.Typeface,
+				textSize:        e.TextSize,
+				positions:       lines,
+			}.Layout(gtx)
+		}),
+
+		layout.Rigid(layout.Spacer{Width: unit.Dp(20)}.Layout),
+
+		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			d := e.Editor.Layout(gtx, e.shaper, e.Font, e.TextSize, textColor, selectionColor)
+			if e.Editor.Len() == 0 {
+				call.Add(gtx.Ops)
+			}
+			return d
+		}),
+	)
+
 	return dims
 }
 
-func (bar LineNumberBar) Layout(gtx layout.Context, th *theme.Theme) layout.Dimensions {
+func (bar lineNumberBar) layoutLine(gtx layout.Context, pos *LineInfo, textColor op.CallOp) layout.Dimensions {
+	stack := op.Offset(image.Point{Y: pos.YOffset}).Push(gtx.Ops)
+
+	tl := widget.Label{
+		Alignment:       text.End,
+		MaxLines:        1,
+		LineHeight:      bar.lineHeight,
+		LineHeightScale: bar.lineHeightScale,
+	}
+
+	d := tl.Layout(gtx, bar.shaper,
+		font.Font{Typeface: bar.typeFace, Weight: font.Normal},
+		bar.textSize,
+		fmt.Sprintf("%d", pos.LineNum),
+		textColor)
+	stack.Pop()
+	return d
+}
+
+func (bar lineNumberBar) Layout(gtx layout.Context) layout.Dimensions {
 	dims := layout.Dimensions{Size: image.Point{X: gtx.Constraints.Min.X}}
 
-	// macro := op.Record(gtx.Ops)
-	for _, pos := range bar.Positions {
-		stack := op.Offset(image.Point{Y: pos.YOffset}).Push(gtx.Ops)
-		d := material.Label(th.Theme, th.TextSize, fmt.Sprintf("%d", pos.LineNum)).Layout(gtx)
-		dims.Size = image.Point{X: max(dims.Size.X, d.Size.X), Y: dims.Size.Y + d.Size.Y}
-		stack.Pop()
+	textColorMacro := op.Record(gtx.Ops)
+	paint.ColorOp{Color: bar.color}.Add(gtx.Ops)
+	textColor := textColorMacro.Stop()
+
+	fake := gtx
+	fake.Ops = &op.Ops{}
+
+	maxWidth := 0
+	{
+		for _, pos := range bar.positions {
+			d := bar.layoutLine(fake, pos, textColor)
+			maxWidth = max(maxWidth, d.Size.X)
+		}
+
+	}
+
+	gtx.Constraints.Max.X = maxWidth
+	gtx.Constraints.Min.X = gtx.Constraints.Max.X
+	for _, pos := range bar.positions {
+		d := bar.layoutLine(gtx, pos, textColor)
+		dims.Size = image.Point{X: maxWidth, Y: dims.Size.Y + d.Size.Y}
 	}
 
 	return dims

--- a/editor/editor_style.go
+++ b/editor/editor_style.go
@@ -64,9 +64,10 @@ type EditorConf struct {
 	LineHeightScale float32
 	//May be helpful for code syntax highlighting.
 	ColorScheme string
+	ShowLineNum bool
 }
 
-func NewEditor(editor *Editor, conf *EditorConf, showLineNum bool, hint string) EditorStyle {
+func NewEditor(editor *Editor, conf *EditorConf, hint string) EditorStyle {
 	return EditorStyle{
 		Editor: editor,
 		Font: font.Font{
@@ -80,7 +81,7 @@ func NewEditor(editor *Editor, conf *EditorConf, showLineNum bool, hint string) 
 		Hint:            hint,
 		HintColor:       MulAlpha(conf.TextColor, 0xbb),
 		SelectionColor:  MulAlpha(conf.SelectionColor, 0x60),
-		ShowLineNum:     showLineNum,
+		ShowLineNum:     conf.ShowLineNum,
 	}
 }
 

--- a/editor/editor_style.go
+++ b/editor/editor_style.go
@@ -35,6 +35,7 @@ type EditorStyle struct {
 	// SelectionColor is the color of the background for selected text.
 	SelectionColor color.NRGBA
 	Editor         *Editor
+	ShowLineNum    bool
 
 	shaper *text.Shaper
 }
@@ -65,7 +66,7 @@ type EditorConf struct {
 	ColorScheme string
 }
 
-func NewEditor(editor *Editor, conf *EditorConf, hint string) EditorStyle {
+func NewEditor(editor *Editor, conf *EditorConf, showLineNum bool, hint string) EditorStyle {
 	return EditorStyle{
 		Editor: editor,
 		Font: font.Font{
@@ -79,6 +80,7 @@ func NewEditor(editor *Editor, conf *EditorConf, hint string) EditorStyle {
 		Hint:            hint,
 		HintColor:       MulAlpha(conf.TextColor, 0xbb),
 		SelectionColor:  MulAlpha(conf.SelectionColor, 0x60),
+		ShowLineNum:     showLineNum,
 	}
 }
 
@@ -112,6 +114,14 @@ func (e EditorStyle) Layout(gtx layout.Context) layout.Dimensions {
 	}
 	e.Editor.LineHeight = e.LineHeight
 	e.Editor.LineHeightScale = e.LineHeightScale
+
+	if !e.ShowLineNum {
+		d := e.Editor.Layout(gtx, e.shaper, e.Font, e.TextSize, textColor, selectionColor)
+		if e.Editor.Len() == 0 {
+			call.Add(gtx.Ops)
+		}
+		return d
+	}
 
 	dims = layout.Flex{
 		Axis: layout.Horizontal,

--- a/editor/editor_style.go
+++ b/editor/editor_style.go
@@ -3,6 +3,8 @@
 package editor
 
 import (
+	"fmt"
+	"image"
 	"image/color"
 
 	"gioui.org/font"
@@ -12,6 +14,8 @@ import (
 	"gioui.org/text"
 	"gioui.org/unit"
 	"gioui.org/widget"
+	"gioui.org/widget/material"
+	"github.com/oligo/gioview/theme"
 )
 
 type EditorStyle struct {
@@ -34,6 +38,10 @@ type EditorStyle struct {
 	Editor         *Editor
 
 	shaper *text.Shaper
+}
+
+type LineNumberBar struct {
+	Positions []*LineInfo
 }
 
 type EditorConf struct {
@@ -102,6 +110,20 @@ func (e EditorStyle) Layout(gtx layout.Context) layout.Dimensions {
 	if e.Editor.Len() == 0 {
 		call.Add(gtx.Ops)
 	}
+	return dims
+}
+
+func (bar LineNumberBar) Layout(gtx layout.Context, th *theme.Theme) layout.Dimensions {
+	dims := layout.Dimensions{Size: image.Point{X: gtx.Constraints.Min.X}}
+
+	// macro := op.Record(gtx.Ops)
+	for _, pos := range bar.Positions {
+		stack := op.Offset(image.Point{Y: pos.YOffset}).Push(gtx.Ops)
+		d := material.Label(th.Theme, th.TextSize, fmt.Sprintf("%d", pos.LineNum)).Layout(gtx)
+		dims.Size = image.Point{X: max(dims.Size.X, d.Size.X), Y: dims.Size.Y + d.Size.Y}
+		stack.Pop()
+	}
+
 	return dims
 }
 

--- a/editor/index.go
+++ b/editor/index.go
@@ -347,10 +347,6 @@ type Region struct {
 	Baseline int
 }
 
-// region is identical to Region except that its coordinates are in document
-// space instead of a widget coordinate space.
-type region = Region
-
 // locate returns highlight regions covering the glyphs that represent the runes in
 // [startRune,endRune). If the rects parameter is non-nil, locate will use it to
 // return results instead of allocating, provided that there is enough capacity.

--- a/editor/text.go
+++ b/editor/text.go
@@ -195,6 +195,7 @@ func (e *textView) closestToXYGraphemes(x fixed.Int26_6, y int) combinedPos {
 
 // getVisibleLines finds all visible physical line positions in the viewport.
 func (e *textView) getVisibleLines() ([]combinedPos, error) {
+	e.makeValid()
 	if e.viewSize.Y <= 0 {
 		return nil, nil
 	}
@@ -674,9 +675,28 @@ func (e *textView) MoveCaret(startDelta, endDelta int) {
 	e.caret.end = e.moveByGraphemes(e.caret.end, endDelta)
 }
 
-// MoveStart moves the caret to the start of the current line, ensuring that the resulting
+// MoveTextStart moves the caret to the start of the text.
+func (e *textView) MoveTextStart(selAct selectionAction) {
+	caret := e.closestToRune(e.caret.end)
+	e.caret.start = 0
+	e.caret.end = caret.runes
+	e.caret.xoff = -caret.x
+	e.updateSelection(selAct)
+	e.clampCursorToGraphemes()
+}
+
+// MoveTextEnd moves the caret to the end of the text.
+func (e *textView) MoveTextEnd(selAct selectionAction) {
+	caret := e.closestToRune(math.MaxInt)
+	e.caret.start = caret.runes
+	e.caret.xoff = fixed.I(e.params.MaxWidth) - caret.x
+	e.updateSelection(selAct)
+	e.clampCursorToGraphemes()
+}
+
+// MoveLineStart moves the caret to the start of the current line, ensuring that the resulting
 // cursor position is on a grapheme cluster boundary.
-func (e *textView) MoveStart(selAct selectionAction) {
+func (e *textView) MoveLineStart(selAct selectionAction) {
 	caret := e.closestToRune(e.caret.start)
 	caret = e.closestToLineCol(caret.lineCol.line, 0)
 	e.caret.start = caret.runes
@@ -685,9 +705,9 @@ func (e *textView) MoveStart(selAct selectionAction) {
 	e.clampCursorToGraphemes()
 }
 
-// MoveEnd moves the caret to the end of the current line, ensuring that the resulting
+// MoveLineEnd moves the caret to the end of the current line, ensuring that the resulting
 // cursor position is on a grapheme cluster boundary.
-func (e *textView) MoveEnd(selAct selectionAction) {
+func (e *textView) MoveLineEnd(selAct selectionAction) {
 	caret := e.closestToRune(e.caret.start)
 	caret = e.closestToLineCol(caret.lineCol.line, math.MaxInt)
 	e.caret.start = caret.runes

--- a/editor/text.go
+++ b/editor/text.go
@@ -206,7 +206,6 @@ func (e *textView) getVisibleLines() ([]combinedPos, error) {
 	// check the succeeding screen lines
 	pos := firstPos
 
-	buf := make([]byte, 1)
 	for pos.lineCol.line <= lastPos.lineCol.line {
 		var r rune
 		var err error
@@ -226,8 +225,6 @@ func (e *textView) getVisibleLines() ([]combinedPos, error) {
 		if pos.lineCol.line >= lastPos.lineCol.line {
 			break
 		}
-
-		e.rr.ReadAt(buf, int64(pos.runes))
 
 		// check the next line
 		pos = e.index.closestToLineCol(screenPos{line: pos.lineCol.line + 1, col: pos.lineCol.col})

--- a/editor/text_iterator.go
+++ b/editor/text_iterator.go
@@ -193,7 +193,7 @@ func (it *textIterator) groupGlyphs(line []glyphStyle) []*glyphSpan {
 	for _, s := range line {
 		span := spans[idx]
 		if len(span.glyphs) <= 0 {
-			span.addFirstGlyph(s, it.lineOff)
+			span.addFirstGlyph(s, float32(it.viewport.Min.X)+it.lineOff.X)
 			continue
 		}
 
@@ -204,7 +204,7 @@ func (it *textIterator) groupGlyphs(line []glyphStyle) []*glyphSpan {
 			idx++
 			spans = append(spans, &glyphSpan{})
 			span := spans[idx]
-			span.addFirstGlyph(s, it.lineOff)
+			span.addFirstGlyph(s, float32(it.viewport.Min.X)+it.lineOff.X)
 		}
 	}
 
@@ -212,13 +212,13 @@ func (it *textIterator) groupGlyphs(line []glyphStyle) []*glyphSpan {
 	return spans
 }
 
-func (span *glyphSpan) addFirstGlyph(s glyphStyle, lineOff f32.Point) {
+func (span *glyphSpan) addFirstGlyph(s glyphStyle, lineOff float32) {
 	span.glyphs = append(span.glyphs, s.g)
 	span.fg = s.fg
 	span.bg = s.bg
 	// offset is where the first glyph character starts
 	// thanks to setting an offset, the rectangle and the glyph can be drawn from X: 0
-	span.offset = float32(s.g.X.Floor() - lineOff.Round().X)
+	span.offset = fixedToFloat(s.g.X) - lineOff
 }
 
 func (span *glyphSpan) calculateBgRect() clip.Rect {

--- a/example/basic/editor-example.go
+++ b/example/basic/editor-example.go
@@ -68,6 +68,7 @@ func (vw *EditorExample) Layout(gtx layout.Context, th *theme.Theme) layout.Dime
 				TextSize:        th.TextSize,
 				LineHeightScale: 1.6,
 				ColorScheme:     "default",
+				ShowLineNum:     true,
 			}
 
 			vw.ed.UpdateTextStyles(stylingText(vw.ed.Text(), vw.patternInput.Text()))
@@ -76,7 +77,7 @@ func (vw *EditorExample) Layout(gtx layout.Context, th *theme.Theme) layout.Dime
 				Left:  unit.Dp(10),
 				Right: unit.Dp(10),
 			}.Layout(gtx, func(gtx C) D {
-				return editor.NewEditor(vw.ed, editorConf, true, "type to input...").Layout(gtx)
+				return editor.NewEditor(vw.ed, editorConf, "type to input...").Layout(gtx)
 			})
 		}),
 	)

--- a/example/basic/editor-example.go
+++ b/example/basic/editor-example.go
@@ -58,21 +58,37 @@ func (vw *EditorExample) Layout(gtx layout.Context, th *theme.Theme) layout.Dime
 
 		layout.Rigid(layout.Spacer{Height: unit.Dp(20)}.Layout),
 
-		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
-			editorConf := &editor.EditorConf{
-				Shaper:          th.Shaper,
-				TextColor:       th.Fg,
-				Bg:              th.Bg,
-				SelectionColor:  th.ContrastBg,
-				TypeFace:        "Go, Helvetica, Arial, sans-serif",
-				TextSize:        th.TextSize,
-				LineHeightScale: 1.6,
-				ColorScheme:     "default",
-			}
+		layout.Rigid(func(gtx C) D {
+			return layout.Flex{
+				Axis:      layout.Horizontal,
+				Alignment: layout.Start,
+			}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					lines, _ := vw.ed.VisibleLines()
+					return editor.LineNumberBar{
+						Positions: lines,
+					}.Layout(gtx, th)
+				}),
 
-			vw.ed.UpdateTextStyles(stylingText(vw.ed.Text(), vw.patternInput.Text()))
+				layout.Rigid(layout.Spacer{Width: unit.Dp(10)}.Layout),
 
-			return editor.NewEditor(vw.ed, editorConf, "type to input...").Layout(gtx)
+				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+					editorConf := &editor.EditorConf{
+						Shaper:          th.Shaper,
+						TextColor:       th.Fg,
+						Bg:              th.Bg,
+						SelectionColor:  th.ContrastBg,
+						TypeFace:        "Go, Helvetica, Arial, sans-serif",
+						TextSize:        th.TextSize,
+						LineHeightScale: 1.6,
+						ColorScheme:     "default",
+					}
+
+					vw.ed.UpdateTextStyles(stylingText(vw.ed.Text(), vw.patternInput.Text()))
+
+					return editor.NewEditor(vw.ed, editorConf, "type to input...").Layout(gtx)
+				}),
+			)
 		}),
 	)
 
@@ -119,7 +135,7 @@ func stylingText(text string, pattern string) []*editor.TextStyle {
 }
 
 var sampleText = `
-🥳🧁🍰🎁🎂🎈🎺🎉🎊
-📧〽️🧿🌶️🔋
-Gio-view is a third-party toolkit that simplifies building user interfaces (UIs) for desktop applications written with the Gio library in Go. It provides pre-built components and widgets, saving you time and effort compared to creating everything from scratch. Gio-view offers a more user-friendly experience for developers new to Gio.
+Gio-view is a third-party toolkit that simplifies building user interfaces (UIs) for desktop applications written with the Gio library in Go.
+It provides pre-built components and widgets, saving you time and effort compared to creating everything from scratch. Gio-view offers a 
+more user-friendly experience for developers new to Gio.
 `

--- a/example/basic/editor-example.go
+++ b/example/basic/editor-example.go
@@ -59,36 +59,25 @@ func (vw *EditorExample) Layout(gtx layout.Context, th *theme.Theme) layout.Dime
 		layout.Rigid(layout.Spacer{Height: unit.Dp(20)}.Layout),
 
 		layout.Rigid(func(gtx C) D {
-			return layout.Flex{
-				Axis:      layout.Horizontal,
-				Alignment: layout.Start,
-			}.Layout(gtx,
-				layout.Rigid(func(gtx C) D {
-					lines, _ := vw.ed.VisibleLines()
-					return editor.LineNumberBar{
-						Positions: lines,
-					}.Layout(gtx, th)
-				}),
+			editorConf := &editor.EditorConf{
+				Shaper:          th.Shaper,
+				TextColor:       th.Fg,
+				Bg:              th.Bg,
+				SelectionColor:  th.ContrastBg,
+				TypeFace:        "Go, Helvetica, Arial, sans-serif",
+				TextSize:        th.TextSize,
+				LineHeightScale: 1.6,
+				ColorScheme:     "default",
+			}
 
-				layout.Rigid(layout.Spacer{Width: unit.Dp(10)}.Layout),
+			vw.ed.UpdateTextStyles(stylingText(vw.ed.Text(), vw.patternInput.Text()))
 
-				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
-					editorConf := &editor.EditorConf{
-						Shaper:          th.Shaper,
-						TextColor:       th.Fg,
-						Bg:              th.Bg,
-						SelectionColor:  th.ContrastBg,
-						TypeFace:        "Go, Helvetica, Arial, sans-serif",
-						TextSize:        th.TextSize,
-						LineHeightScale: 1.6,
-						ColorScheme:     "default",
-					}
-
-					vw.ed.UpdateTextStyles(stylingText(vw.ed.Text(), vw.patternInput.Text()))
-
-					return editor.NewEditor(vw.ed, editorConf, "type to input...").Layout(gtx)
-				}),
-			)
+			return layout.Inset{
+				Left:  unit.Dp(10),
+				Right: unit.Dp(10),
+			}.Layout(gtx, func(gtx C) D {
+				return editor.NewEditor(vw.ed, editorConf, "type to input...").Layout(gtx)
+			})
 		}),
 	)
 

--- a/example/basic/editor-example.go
+++ b/example/basic/editor-example.go
@@ -76,7 +76,7 @@ func (vw *EditorExample) Layout(gtx layout.Context, th *theme.Theme) layout.Dime
 				Left:  unit.Dp(10),
 				Right: unit.Dp(10),
 			}.Layout(gtx, func(gtx C) D {
-				return editor.NewEditor(vw.ed, editorConf, "type to input...").Layout(gtx)
+				return editor.NewEditor(vw.ed, editorConf, true, "type to input...").Layout(gtx)
 			})
 		}),
 	)

--- a/example/basic/editor-example.go
+++ b/example/basic/editor-example.go
@@ -60,15 +60,17 @@ func (vw *EditorExample) Layout(gtx layout.Context, th *theme.Theme) layout.Dime
 
 		layout.Rigid(func(gtx C) D {
 			editorConf := &editor.EditorConf{
-				Shaper:          th.Shaper,
-				TextColor:       th.Fg,
-				Bg:              th.Bg,
-				SelectionColor:  th.ContrastBg,
-				TypeFace:        "Go, Helvetica, Arial, sans-serif",
-				TextSize:        th.TextSize,
-				LineHeightScale: 1.6,
-				ColorScheme:     "default",
-				ShowLineNum:     true,
+				Shaper:             th.Shaper,
+				TextColor:          th.Fg,
+				Bg:                 th.Bg,
+				SelectionColor:     th.ContrastBg,
+				LineHighlightColor: th.Fg,
+				TypeFace:           "Go, Helvetica, Arial, sans-serif",
+				TextSize:           th.TextSize,
+				LineHeightScale:    1.6,
+				ColorScheme:        "default",
+				ShowLineNum:        true,
+				LineNumPadding:     unit.Dp(24),
 			}
 
 			vw.ed.UpdateTextStyles(stylingText(vw.ed.Text(), vw.patternInput.Text()))


### PR DESCRIPTION
Add efficient line number rendering support to editor. And it can be disabled by setting showLineNum to false.