### PR TITLE
Let user to customise tab character

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -69,6 +69,9 @@ type Editor struct {
 	// selected text.
 	KeepFocus bool
 
+	// TabCharacter is the character used to represent a tab. If empty, \t is used.
+	TabCharacter string
+
 	buffer     *editBuffer
 	textStyles []*TextStyle
 	// Match ranges in rune offset, for text search.
@@ -528,7 +531,7 @@ func (e *Editor) command(gtx layout.Context, k key.Event) (EditorEvent, bool) {
 		}
 	case key.NameTab:
 		if !e.ReadOnly {
-			if e.Insert("\t") != 0 {
+			if e.Insert(e.TabCharacter) != 0 {
 				return ChangeEvent{}, true
 			}
 		}

--- a/editor/editor_style.go
+++ b/editor/editor_style.go
@@ -15,6 +15,7 @@ import (
 	"gioui.org/text"
 	"gioui.org/unit"
 	"gioui.org/widget"
+
 	"github.com/oligo/gioview/misc"
 )
 
@@ -79,9 +80,16 @@ type EditorConf struct {
 	ShowLineNum bool
 	// padding between line number and the editor content.
 	LineNumPadding unit.Dp
+
+	// TabCharacter is the character used to represent a tab.
+	TabCharacter string
 }
 
 func NewEditor(editor *Editor, conf *EditorConf, hint string) EditorStyle {
+	editor.TabCharacter = "\t"
+	if conf.TabCharacter != "" {
+		editor.TabCharacter = conf.TabCharacter
+	}
 
 	es := EditorStyle{
 		Editor: editor,


### PR DESCRIPTION
This PR adds an option to editor style to let user customise the tab character for example four spaces instead of tab character. 