### PR TITLE
Previously unable to move word left/right on a single line, and move to punctuation instead of space.

### DIFF
--- a/editor/editor.go
+++ b/editor/editor.go
@@ -476,12 +476,15 @@ func (e *Editor) command(gtx layout.Context, k key.Event) (EditorEvent, bool) {
 	if gtx.Locale.Direction.Progression() == system.TowardOrigin {
 		direction = -1
 	}
-	moveByWord := k.Modifiers.Contain(key.ModShortcutAlt)
 	selAct := selectionClear
 	if k.Modifiers.Contain(key.ModShift) {
 		selAct = selectionExtend
 	}
-	if k.Modifiers.Contain(key.ModShortcut) {
+
+	moveByWord := k.Modifiers.Contain(key.ModShortcutAlt)
+	leftOrRightArrow := k.Name == key.NameLeftArrow || k.Name == key.NameRightArrow
+
+	if k.Modifiers.Contain(key.ModShortcut) && !leftOrRightArrow {
 		switch k.Name {
 		// Initiate a paste operation, by requesting the clipboard contents; other
 		// half is in Editor.processKey() under clipboard.Event.

--- a/editor/text.go
+++ b/editor/text.go
@@ -867,7 +867,7 @@ func (e *textView) MoveWord(distance int, selAct selectionAction) {
 		}
 		e.MoveCaret(direction, 0)
 		caret = e.closestToRune(e.caret.start)
-		for r := next(); !unicode.IsSpace(r) && !atEnd(); r = next() {
+		for r := next(); !unicode.IsSpace(r) && !unicode.IsPunct(r) && !atEnd(); r = next() {
 			e.MoveCaret(direction, 0)
 			caret = e.closestToRune(e.caret.start)
 		}


### PR DESCRIPTION
Moving by word gets hung up in (left or right arrow) gets hung up in the check for ModShortcut. (copy/paste/etc). In this case we should just check if the modifier comes along with an arrow key.

This also add checking for _Unicode Punctuation_ instead of just spaces when moving a word.

Note, I'm not sure that this is the correct solution to this problem. I was hoping for some insights on how this might be done better.

However, this was the "fastest" way to get the behavior I wanted. Let me know what I can do here as to not break previous behavior (unless we want that).